### PR TITLE
Fix resetting statusbar and feedback on section reset

### DIFF
--- a/src/scripts/h5p-structure-strip-section.js
+++ b/src/scripts/h5p-structure-strip-section.js
@@ -91,6 +91,8 @@ export default class StructureStripSection {
    */
   reset() {
     this.inputField.value = '';
+    this.setStatus('');
+    this.setProgressBar(0);
   }
 
   /**


### PR DESCRIPTION
I didn't realize these two needed to be reset as well if the feedback mode is 'while typing'